### PR TITLE
Made ordlookup work on py3

### DIFF
--- a/ordlookup/__init__.py
+++ b/ordlookup/__init__.py
@@ -1,3 +1,4 @@
+import sys
 from __future__ import absolute_import
 from . import ws2_32
 from . import oleaut32
@@ -14,8 +15,17 @@ ords = {
     b'oleaut32.dll': oleaut32.ord_names,
 }
 
+PY3 = sys.version_info > (3,)
 
-def ordLookup(libname, ord, make_name=False):
+if PY3:
+    def formatOrdString(ord_val):
+        return 'ord{}'.format(ord_val).encode()
+else:
+    def formatOrdString(ord_val):
+        return b'ord%d' % ord_val
+
+
+def ordLookup(libname, ord_val, make_name=False):
     '''
     Lookup a name for the given ordinal if it's in our
     database.
@@ -23,9 +33,9 @@ def ordLookup(libname, ord, make_name=False):
     names = ords.get(libname.lower())
     if names is None:
         if make_name is True:
-            return b'ord%d' % ord
+            return formatOrdString(ord_val)
         return None
-    name = names.get(ord)
+    name = names.get(ord_val)
     if name is None:
-        return b'ord%d' % ord
+        return formatOrdString(ord_val)
     return name


### PR DESCRIPTION
Fix for this error:

```
File "C:\Users\caleb\test\receptor\current\dcode.zip\ordlookup\__init__.py", line 27, in ordLookup
    return b'ord{}'.format(ord)
AttributeError: 'bytes' object has no attribute 'format'
```