### PR TITLE
Fixed silly __future__ import error

### DIFF
--- a/ordlookup/__init__.py
+++ b/ordlookup/__init__.py
@@ -1,5 +1,5 @@
-import sys
 from __future__ import absolute_import
+import sys
 from . import ws2_32
 from . import oleaut32
 


### PR DESCRIPTION
Fixed this error (not sure why I wasn't getting this before): `from __future__ imports must occur at the beginning of the file`